### PR TITLE
Option to override OR append content and minor formatting

### DIFF
--- a/configure.phtml
+++ b/configure.phtml
@@ -1,53 +1,58 @@
 <form action="<?php echo _url('extension', 'configure', 'e', urlencode($this->getName())); ?>" method="post">
-    <input type="hidden" name="_csrf" value="<?php echo FreshRSS_Auth::csrfToken(); ?>" />
-    <div class="form-group">
+	<input type="hidden" name="_csrf" value="<?php echo FreshRSS_Auth::csrfToken(); ?>" />
+	<div class="form-group">
 
-	<p> Configure the following values according to the <a href="https://github.com/printfuck/xExtension-Readable#setup" target="_blank">instructions</a> </p>
-	<label class="group-name" for="read_readability_host">Readbility Host</label>
-	<div class="group-controls">
-	    <input type="text" id="read_readability_host" name="read_readability_host" value="<?php echo $this->getReadHost(); ?>" min="50" data-leave-validation="1">
+		<p> Configure the following values according to the <a href="https://github.com/printfuck/xExtension-Readable#setup" target="_blank">instructions</a> </p>
+		<label class="group-name" for="read_readability_host">Readbility Host</label>
+		<div class="group-controls">
+			<input type="text" id="read_readability_host" name="read_readability_host" value="<?php echo $this->getReadHost(); ?>" min="50" data-leave-validation="1">
+		</div>
+
+		<label class="group-name" for="read_mercury_host">Mercury Host</label>
+		<div class="group-controls">
+			<input type="text" id="read_mercury_host" name="read_mercury_host" value="<?php echo $this->getMercHost(); ?>" min="100" data-leave-validation="1">
+		</div>
 	</div>
 
-	<label class="group-name" for="read_mercury_host">Mercury Host</label>
-	<div class="group-controls">
-	    <input type="text" id="read_mercury_host" name="read_mercury_host" value="<?php echo $this->getMercHost(); ?>" min="100" data-leave-validation="1">
-	</div>
-    </div>
-
-    <div>
-	<p>Shown below are the feeds, to which this addon will apply either Mercury or Readability Parsing. Remember to hit <b>Submit</b> at the bottom after making changes.</p>
-	<?php
+	<div>
+		<p>Shown below are the feeds, to which this addon will apply either Mercury or Readability Parsing. Remember to hit <b>Submit</b> at the bottom after making changes.</p>
+		<?php
 		foreach ($this->getCategories() as $c) {
-	?>
-
-		<h3><?php echo $c->name()?></h3>
-		<table>
-		<tr><td>Mercury</td><td>Readability</td><td>override_content</td><td>Feed</td></tr>
-		<?php
-			foreach ( $c->feeds() as $f) {
 		?>
 
-			<tr>
-			<td> <input type="checkbox" id="merc_<?php echo $f->id() ?>" name="merc_<?php echo $f->id() ?>" value="1" <?php echo $this->getConfStoreM($f->id()) ? 'checked' : ''; ?>> </td>
-			<td> <input type="checkbox" id="read_<?php echo $f->id() ?>" name="read_<?php echo $f->id() ?>" value="1" <?php echo $this->getConfStoreR($f->id()) ? 'checked' : ''; ?>> </td>
-			<td> <input type="checkbox" id="override_content_<?php echo $f->id() ?>" name="override_content_<?php echo $f->id() ?>" value="1" <?php echo $this->getConfStoreO($f->id()) ? 'checked' : ''; ?>> </td>
-	    		<td><?php echo $f->name() ?></td>
-			</tr>
-		
+			<h3><?php echo $c->name() ?></h3>
+			<table>
+				<tr>
+					<td>Mercury</td>
+					<td>Readability</td>
+					<td>override_content</td>
+					<td>Feed</td>
+				</tr>
+				<?php
+				foreach ($c->feeds() as $f) {
+				?>
+
+					<tr>
+						<td> <input type="checkbox" id="merc_<?php echo $f->id() ?>" name="merc_<?php echo $f->id() ?>" value="1" <?php echo $this->getConfStoreM($f->id()) ? 'checked' : ''; ?>> </td>
+						<td> <input type="checkbox" id="read_<?php echo $f->id() ?>" name="read_<?php echo $f->id() ?>" value="1" <?php echo $this->getConfStoreR($f->id()) ? 'checked' : ''; ?>> </td>
+						<td> <input type="checkbox" id="override_content_<?php echo $f->id() ?>" name="override_content_<?php echo $f->id() ?>" value="1" <?php echo $this->getConfStoreO($f->id()) ? 'checked' : ''; ?>> </td>
+						<td><?php echo $f->name() ?></td>
+					</tr>
+
+				<?php
+				}
+				?>
+			</table>
 		<?php
-			}
-		?>
-		</table>
-	<?php
 		}
-	?>
-	<br>
-    </div>
-
-    <div class="form-group form-actions">
-	<div class="group-controls">
-	    <button type="submit" class="btn btn-important"><?php echo _t('gen.action.submit'); ?></button>
-	    <button type="reset" class="btn"><?php echo _t('gen.action.cancel'); ?></button>
+		?>
+		<br>
 	</div>
-    </div>
+
+	<div class="form-group form-actions">
+		<div class="group-controls">
+			<button type="submit" class="btn btn-important"><?php echo _t('gen.action.submit'); ?></button>
+			<button type="reset" class="btn"><?php echo _t('gen.action.cancel'); ?></button>
+		</div>
+	</div>
 </form>

--- a/configure.phtml
+++ b/configure.phtml
@@ -22,7 +22,7 @@
 
 		<h3><?php echo $c->name()?></h3>
 		<table>
-		<tr><td>Mercury</td><td>Readability</td><td>Feed</td></tr>
+		<tr><td>Mercury</td><td>Readability</td><td>override_content</td><td>Feed</td></tr>
 		<?php
 			foreach ( $c->feeds() as $f) {
 		?>
@@ -30,6 +30,7 @@
 			<tr>
 			<td> <input type="checkbox" id="merc_<?php echo $f->id() ?>" name="merc_<?php echo $f->id() ?>" value="1" <?php echo $this->getConfStoreM($f->id()) ? 'checked' : ''; ?>> </td>
 			<td> <input type="checkbox" id="read_<?php echo $f->id() ?>" name="read_<?php echo $f->id() ?>" value="1" <?php echo $this->getConfStoreR($f->id()) ? 'checked' : ''; ?>> </td>
+			<td> <input type="checkbox" id="override_content_<?php echo $f->id() ?>" name="override_content_<?php echo $f->id() ?>" value="1" <?php echo $this->getConfStoreO($f->id()) ? 'checked' : ''; ?>> </td>
 	    		<td><?php echo $f->name() ?></td>
 			</tr>
 		

--- a/extension.php
+++ b/extension.php
@@ -1,179 +1,186 @@
 <?php
 
-class ReadableExtension extends Minz_Extension {
+class ReadableExtension extends Minz_Extension
+{
 
-    private $readHost;
-    private $mercHost;
-    private $feeds;
-    private $cats;
-    private $mStore;
-    private $rStore;
+	private $readHost;
+	private $mercHost;
+	private $feeds;
+	private $cats;
+	private $mStore;
+	private $rStore;
 	private $oStore; // override_content
 
-    public function init() {
+	public function init()
+	{
 
-        $this->registerHook('entry_before_insert', array($this, 'fetchStuff'));
-    }
-
-    public function fetchStuff($entry) {
-	
-	$this->loadConfigValues();
-	$host = '';
-	$id = $entry->toArray()['id_feed'];
-
-	if ( array_key_exists($id, $this->mStore) ) {
-		$host = $this->mercHost."/parser?url=".$entry->link();
-		$c = curl_init($host);
-    	}
-
-	if ( array_key_exists($id, $this->rStore) ) {
-		$host = $this->readHost;
-		$c = curl_init($host);
-		$data = "{\"url\": \"" . $entry->link() ."\"}";
-		$headers[] = 'Content-Type: application/json';
-		curl_setopt($c, CURLOPT_POSTFIELDS, $data);
-		curl_setopt($c, CURLOPT_HTTPHEADER, $headers);
+		$this->registerHook('entry_before_insert', array($this, 'fetchStuff'));
 	}
 
-	if ($host === '')
-		return $entry;
+	public function fetchStuff($entry)
+	{
 
-	curl_setopt($c, CURLOPT_RETURNTRANSFER, 1);
-	$result = curl_exec($c);
-	$c_status = curl_getinfo($c, CURLINFO_HTTP_CODE);
-	//$c_error = curl_error($c);
-	curl_close($c);
+		$this->loadConfigValues();
+		$host = '';
+		$id = $entry->toArray()['id_feed'];
 
-	if ($c_status !== 200) {
-	    return $entry;
-	}
-	$val = json_decode($result, true);
-	if (empty($val) || empty($val["content"])) {
-		return $entry;
-	}
-	//$entry->_content($val["content"]);  // original line
-	/* override_content:
+		if (array_key_exists($id, $this->mStore)) {
+			$host = $this->mercHost . "/parser?url=" . $entry->link();
+			$c = curl_init($host);
+		}
+
+		if (array_key_exists($id, $this->rStore)) {
+			$host = $this->readHost;
+			$c = curl_init($host);
+			$data = "{\"url\": \"" . $entry->link() . "\"}";
+			$headers[] = 'Content-Type: application/json';
+			curl_setopt($c, CURLOPT_POSTFIELDS, $data);
+			curl_setopt($c, CURLOPT_HTTPHEADER, $headers);
+		}
+
+		if ($host === '')
+			return $entry;
+
+		curl_setopt($c, CURLOPT_RETURNTRANSFER, 1);
+		$result = curl_exec($c);
+		$c_status = curl_getinfo($c, CURLINFO_HTTP_CODE);
+		//$c_error = curl_error($c);
+		curl_close($c);
+
+		if ($c_status !== 200) {
+			return $entry;
+		}
+		$val = json_decode($result, true);
+		if (empty($val) || empty($val["content"])) {
+			return $entry;
+		}
+		//$entry->_content($val["content"]);  // original line
+		/* override_content:
 	 * If content override is not requested, append content
 	 */
-	if ( array_key_exists($id, $this->oStore) ) {
-		$entry->_content($val["content"]);
-	} else {
-		$entry->_content($entry->content() . $val["content"]);
+		if (array_key_exists($id, $this->oStore)) {
+			$entry->_content($val["content"]);
+		} else {
+			$entry->_content($entry->content() . $val["content"]);
+		}
+
+		return $entry;
 	}
 
-	return $entry;
-}
-
-    /*
+	/*
      * These are called from configure.phtml, which is controlled by handleConfigureAction(), 
      * thus values are already fetched from userconfig and FeedDAO.
      */
 
-    public function getReadHost() {
-	    return $this->readHost;
-    }
+	public function getReadHost()
+	{
+		return $this->readHost;
+	}
 
-    public function getMercHost() {
-	    return $this->mercHost;
-    }
+	public function getMercHost()
+	{
+		return $this->mercHost;
+	}
 
-    public function getFeeds() {
-	    return $this->feeds;
-    }
+	public function getFeeds()
+	{
+		return $this->feeds;
+	}
 
-    public function getCategories() {
-	    return $this->cats;
-    }
+	public function getCategories()
+	{
+		return $this->cats;
+	}
 
-    /*
+	/*
     Loading basic variables from user storage
     */
-    public function loadConfigValues()
-    {
-        if (!class_exists('FreshRSS_Context', false) || null === FreshRSS_Context::$user_conf) {
-            return;
+	public function loadConfigValues()
+	{
+		if (!class_exists('FreshRSS_Context', false) || null === FreshRSS_Context::$user_conf) {
+			return;
 		}
 
-        if (FreshRSS_Context::$user_conf->read_ext_read_host != '') {
-            $this->readHost = FreshRSS_Context::$user_conf->read_ext_read_host;
-        }
-        if (FreshRSS_Context::$user_conf->read_ext_merc_host != '') {
-            $this->mercHost = FreshRSS_Context::$user_conf->read_ext_merc_host;
-        }
-        if (FreshRSS_Context::$user_conf->read_ext_mercury != '') {
-            $this->mStore = json_decode(FreshRSS_Context::$user_conf->read_ext_mercury, true);
-		} else {
-	    	$this->mStore = [];
+		if (FreshRSS_Context::$user_conf->read_ext_read_host != '') {
+			$this->readHost = FreshRSS_Context::$user_conf->read_ext_read_host;
 		}
-        if (FreshRSS_Context::$user_conf->read_ext_readability != '') {
-            $this->rStore = json_decode(FreshRSS_Context::$user_conf->read_ext_readability, true);
+		if (FreshRSS_Context::$user_conf->read_ext_merc_host != '') {
+			$this->mercHost = FreshRSS_Context::$user_conf->read_ext_merc_host;
+		}
+		if (FreshRSS_Context::$user_conf->read_ext_mercury != '') {
+			$this->mStore = json_decode(FreshRSS_Context::$user_conf->read_ext_mercury, true);
 		} else {
-	    	$this->rStore = [];
+			$this->mStore = [];
+		}
+		if (FreshRSS_Context::$user_conf->read_ext_readability != '') {
+			$this->rStore = json_decode(FreshRSS_Context::$user_conf->read_ext_readability, true);
+		} else {
+			$this->rStore = [];
 		}
 		// override_content
 		if (FreshRSS_Context::$user_conf->read_ext_override != '') {
-            $this->oStore = json_decode(FreshRSS_Context::$user_conf->read_ext_override, true);
+			$this->oStore = json_decode(FreshRSS_Context::$user_conf->read_ext_override, true);
 		} else {
-	    	$this->oStore = [];
+			$this->oStore = [];
 		}
-    }
+	}
 
-    public function getConfStoreR($id ) {
+	public function getConfStoreR($id)
+	{
 		return array_key_exists($id, $this->rStore);
-    }
-    public function getConfStoreM($id ) {
+	}
+	public function getConfStoreM($id)
+	{
 		return array_key_exists($id, $this->mStore);
-    }
+	}
 	// override_content
-	public function getConfStoreO($id ) {
+	public function getConfStoreO($id)
+	{
 		return array_key_exists($id, $this->oStore);
-    }
-    
-    /*
+	}
+
+	/*
      * handleConfigureAction() is only executed on loading and saving the extenstion's configuration page.
      * If the Request type is POST, values are being saved. It looks weird, but I copied it from another example and it works flawlessly.
      */
-    public function handleConfigureAction()
-    {
-	$feedDAO = FreshRSS_Factory::createFeedDao();
-	$catDAO = FreshRSS_Factory::createCategoryDao();
-	$this->feeds = $feedDAO->listFeeds();
-	$this->cats = $catDAO->listCategories(true,false); 
+	public function handleConfigureAction()
+	{
+		$feedDAO = FreshRSS_Factory::createFeedDao();
+		$catDAO = FreshRSS_Factory::createCategoryDao();
+		$this->feeds = $feedDAO->listFeeds();
+		$this->cats = $catDAO->listCategories(true, false);
 
-	if (Minz_Request::isPost()) {
-	    $mstore = [];
-	    $rstore = [];
-		$override_store = [];  // override_content
-	    foreach ( $this->feeds as $f ) {
-	            //I rather encode only a few 'true' entries, than 400+ false entries + the few 'true' entries	    
-		    if ((bool)Minz_Request::param("read_".$f->id(), 0)){
-			    $rstore[$f->id()] = true;
-		    }
+		if (Minz_Request::isPost()) {
+			$mstore = [];
+			$rstore = [];
+			$override_store = [];  // override_content
+			foreach ($this->feeds as $f) {
+				//I rather encode only a few 'true' entries, than 400+ false entries + the few 'true' entries	    
+				if ((bool)Minz_Request::param("read_" . $f->id(), 0)) {
+					$rstore[$f->id()] = true;
+				}
 
-		    if ( (bool)Minz_Request::param("merc_".$f->id(), 0) ) {
-			    $mstore[$f->id()] = true;
-		    }
+				if ((bool)Minz_Request::param("merc_" . $f->id(), 0)) {
+					$mstore[$f->id()] = true;
+				}
 
-			// override_content
-			if ( (bool)Minz_Request::param("override_content_".$f->id(), 0) ) {
-			    $override_store[$f->id()] = true;
-		    }
-	    }
-	    // I don't know if it's possible to save arrays, so it's encoded with json
-	    FreshRSS_Context::$user_conf->read_ext_mercury = (string)json_encode($mstore);
-	    FreshRSS_Context::$user_conf->read_ext_readability = (string)json_encode($rstore);
-		FreshRSS_Context::$user_conf->read_ext_override = (string)json_encode($override_store);  // override_content
+				// override_content
+				if ((bool)Minz_Request::param("override_content_" . $f->id(), 0)) {
+					$override_store[$f->id()] = true;
+				}
+			}
+			// I don't know if it's possible to save arrays, so it's encoded with json
+			FreshRSS_Context::$user_conf->read_ext_mercury = (string)json_encode($mstore);
+			FreshRSS_Context::$user_conf->read_ext_readability = (string)json_encode($rstore);
+			FreshRSS_Context::$user_conf->read_ext_override = (string)json_encode($override_store);  // override_content
 
-	    FreshRSS_Context::$user_conf->read_ext_merc_host = (string)Minz_Request::param('read_mercury_host');
-	    FreshRSS_Context::$user_conf->read_ext_read_host = (string)Minz_Request::param('read_readability_host');
-	
-	    FreshRSS_Context::$user_conf->save();
+			FreshRSS_Context::$user_conf->read_ext_merc_host = (string)Minz_Request::param('read_mercury_host');
+			FreshRSS_Context::$user_conf->read_ext_read_host = (string)Minz_Request::param('read_readability_host');
+
+			FreshRSS_Context::$user_conf->save();
+		}
+
+
+		$this->loadConfigValues();
 	}
-
-
-	$this->loadConfigValues();
-    }
-
-
-
 }


### PR DESCRIPTION
I added a configuration option for each feed to choose whether to override content or not (in which case, it just appends the content). This is useful for feeds that contain a summary that is either not available in the article page, or is not picked up by merc/read. It's nice to just get a summary if you don't care enough to read the whole article.
Also applied some standard PHP formatting rules in the files.